### PR TITLE
Add a `readonly` modifier to a argument

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -1,6 +1,6 @@
 import shuffle from "./mod.ts";
 
-const arr = Array(10).fill(0).map((x, i) => i);
+const arr = Array(10).fill(0).map((_, i) => i);
 
 console.log(`origin array:\t${arr.join(",")}`);
 console.log(`shuffle array:\t${shuffle(arr).join(",")}`);

--- a/mod.ts
+++ b/mod.ts
@@ -3,7 +3,7 @@
  * [Fisher-Yates shuffle](https://en.wikipedia.org/wiki/Fisher-Yates_shuffle).
  * @param arr The array to shuffle
  */
-export default function shuffle<T>(arr: T[]): T[] {
+export default function shuffle<T>(arr: readonly T[]): T[] {
   const length = arr.length;
   const result = [...arr];
 


### PR DESCRIPTION
Since the `shuffle` function does not affect a argument, I added a `readonly` modifier.